### PR TITLE
表加入别名，生成Mapper文件，使用别名代替Pre_表名，解决addDBFields = false，也生成DBFields对应的Res…

### DIFF
--- a/src/main/java/com/lifeonwalden/codeGenerator/bean/Table.java
+++ b/src/main/java/com/lifeonwalden/codeGenerator/bean/Table.java
@@ -16,6 +16,9 @@ public class Table implements Serializable {
     private String name;
 
     @XStreamAsAttribute
+    private String alias;
+
+    @XStreamAsAttribute
     private String note;
 
     @XStreamAsAttribute
@@ -54,6 +57,14 @@ public class Table implements Serializable {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getAlias() {
+        return alias;
+    }
+
+    public void setAlias(String alias) {
+        this.alias = alias;
     }
 
     public String getNote() {

--- a/src/main/java/com/lifeonwalden/codeGenerator/mybatis/impl/BaseColumnListWithPrefixElementGenerator.java
+++ b/src/main/java/com/lifeonwalden/codeGenerator/mybatis/impl/BaseColumnListWithPrefixElementGenerator.java
@@ -16,10 +16,16 @@ public class BaseColumnListWithPrefixElementGenerator implements TableElementGen
         XmlElement element = new XmlElement(XMLTag.SQL.getName());
 
         element.addAttribute(new Attribute(XMLAttribute.ID.getName(), "baseColumnListWithPrefix"));
-
+        String alias = table.getAlias();
         StringBuilder sb = new StringBuilder();
+
         for (Column column : table.getColumns()) {
-            sb.append("pre_").append(table.getName().toLowerCase()).append(".").append(column.getName()).append(",");
+            if (alias != null && alias.length() >= 1) {
+                sb.append(alias).append(".").append(column.getName()).append(",");
+            }
+            else {
+                sb.append("pre_").append(table.getName().toLowerCase()).append(".").append(column.getName()).append(",");
+            }
         }
 
         if (sb.length() > 0) {

--- a/src/main/java/com/lifeonwalden/codeGenerator/mybatis/impl/ColumnListWithPrefixElementXcludeDBFieldGenerator.java
+++ b/src/main/java/com/lifeonwalden/codeGenerator/mybatis/impl/ColumnListWithPrefixElementXcludeDBFieldGenerator.java
@@ -16,7 +16,7 @@ public class ColumnListWithPrefixElementXcludeDBFieldGenerator implements TableE
         XmlElement element = new XmlElement(XMLTag.SQL.getName());
 
         element.addAttribute(new Attribute(XMLAttribute.ID.getName(), "columnListWithPrefixXcludeDBField"));
-
+        String alias = table.getAlias();
         StringBuilder sb = new StringBuilder();
         for (Column column : table.getColumns()) {
             if (column.getName().equalsIgnoreCase("createTime") || column.getName().equalsIgnoreCase("createUser")
@@ -25,7 +25,13 @@ public class ColumnListWithPrefixElementXcludeDBFieldGenerator implements TableE
                 continue;
             }
 
-            sb.append("pre_").append(table.getName().toLowerCase()).append(".").append(column.getName()).append(",");
+            if (alias != null && alias.length() >= 1) {
+                sb.append(alias).append(".").append(column.getName()).append(",");
+            }
+            else {
+                sb.append("pre_").append(table.getName().toLowerCase()).append(".").append(column.getName()).append(",");
+            }
+        
         }
 
         if (sb.length() > 0) {

--- a/src/main/java/com/lifeonwalden/codeGenerator/mybatis/impl/XMLMapperGenerator.java
+++ b/src/main/java/com/lifeonwalden/codeGenerator/mybatis/impl/XMLMapperGenerator.java
@@ -36,14 +36,17 @@ public class XMLMapperGenerator implements DomGenerator {
     @Override
     public String generate(Table table, Config config) {
         Document document = new Document(XmlConstants.MYBATIS3_MAPPER_PUBLIC_ID, XmlConstants.MYBATIS3_MAPPER_SYSTEM_ID, config.getEncoding());
-
+        Boolean addDBFields = table.getAddDBFields();
+        addDBFields = addDBFields != null && addDBFields;//避免返回null的情况
         XmlElement root = rootElementGenerator.getElement(table, config);
         root.addElement(baseResultMapElementGenerator.getElement(table, config));
         root.addElement(baseColumnListElementGenerator.getElement(table, config));
         root.addElement(baseColumnListWithPrefixElementGenerator.getElement(table, config));
-        root.addElement(resultMapElementXcludeDBFieldGenerator.getElement(table, config));
-        root.addElement(columnListElementXcludeDBFieldGenerator.getElement(table, config));
-        root.addElement(columnListWithPrefixElementXcludeDBFieldGenerator.getElement(table, config));
+        if (addDBFields) {
+            root.addElement(resultMapElementXcludeDBFieldGenerator.getElement(table, config));
+            root.addElement(columnListElementXcludeDBFieldGenerator.getElement(table, config));
+            root.addElement(columnListWithPrefixElementXcludeDBFieldGenerator.getElement(table, config));
+        }
         root.addElement(sqlDynamicUpdateElementGenerator.getElement(table, config));
         root.addElement(sqlUpdateElementGenerator.getElement(table, config));
         root.addElement(sqlInsertElementGenerator.getElement(table, config));
@@ -59,7 +62,7 @@ public class XMLMapperGenerator implements DomGenerator {
             root.addElement(updateDynamicElementGenerator.getElement(table, config));
             root.addElement(updateFullElementGenerator.getElement(table, config));
 
-            if (null == table.getAddDBFields() || table.getAddDBFields()) {
+            if (addDBFields) {//null == table.getAddDBFields() || table.getAddDBFields()
                 root.addElement(logicalDeleteElementGenerator.getElement(table, config));
             }
         }


### PR DESCRIPTION
Table表加入别名，可用于生成Controller的前缀，以及Mapper文件中，使用别名代替Pre_表名，解决addDBFields = false，也生成DBFields对应的ResultMap以及若个sql条段